### PR TITLE
fix: .readthedocs.yml indentation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -23,4 +23,4 @@ python:
     - requirements: docs/requirements.txt
     # Install package using pip for the build (needed for autodoc)
     - method: pip
-        path: .
+      path: .


### PR DESCRIPTION
It was tricky to track down the error, which is reported here:
* [r2b2 \| Read the Docs build 10467956 failure](https://readthedocs.org/projects/r2b2/builds/10467956/)

```
Error
Problem in your project's configuration. Parse error in .readthedocs.yml: YAML:
mapping values are not allowed here in "<unicode string>"
line 26, column 13: path: .
```

This led me to the indentation issue in our YAML:
* [Error parsing yaml file: mapping values are not allowed here \- Stack Overflow](https://stackoverflow.com/a/41236822/507544)

It might be a bug in cookiecutter-pylibrary.

But the build works now, as reflected at [R2B2 Builds \| Read the Docs](https://readthedocs.org/projects/r2b2/builds/)