### PR TITLE
Switch to autoapi from autodoc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,8 +4,7 @@ from __future__ import unicode_literals
 import os
 
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.autosummary',
+    'autoapi.extension',
     'sphinx.ext.coverage',
     'sphinx.ext.doctest',
     'sphinx.ext.extlinks',
@@ -21,6 +20,9 @@ year = '2019-2020'
 author = 'R2B2 Team'
 copyright = '{0}, {1}'.format(year, author)
 version = release = '0.1.0'
+
+autoapi_type = 'python'
+autoapi_dirs = ['../src']
 
 pygments_style = 'trac'
 templates_path = ['.']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,6 @@ Contents
    readme
    installation
    usage
-   reference/index
    contributing
    authors
    changelog

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -1,7 +1,0 @@
-Reference
-=========
-
-.. toctree::
-    :glob:
-
-    r2b2*

--- a/docs/reference/r2b2.rst
+++ b/docs/reference/r2b2.rst
@@ -1,9 +1,0 @@
-r2b2
-====
-
-.. testsetup::
-
-    from r2b2 import *
-
-.. automodule:: r2b2
-    :members:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 sphinx>=1.3
 sphinx-rtd-theme
+sphinx-autoapi


### PR DESCRIPTION
Thanks to Sarah's proposal at #6, I finally realized that autodoc doesn't automate what I assumed it did. It requires individually listing modules, and ongoing maintenance based on new modules, and requires installing dependencies just to produce documentation.

Based on the advice to use `autoapi` at [Sphinx autodoc is not automatic enough](https://stackoverflow.com/a/57860910/507544), I tried it and love it.

See the way it looks at [docs via autoapi branch - Contents — R2B2 0\.1\.0 documentation](https://r2b2.readthedocs.io/en/autoapi/)

Note that the new docstring-based documentation is now in the API Reference section at the bottom of the index.

I'd prefer to have it higher up, which I guess will require overriding some of the template files, which we can come back to if desired.

Note also the options around how to document classes, based on either the Class docstring or the __init__ docstring or both: 
https://sphinx-autoapi.readthedocs.io/en/latest/reference/config.html#confval-autoapi_python_class_content