### PR TITLE
fix for issue #20

### DIFF
--- a/src/r2b2/audit.py
+++ b/src/r2b2/audit.py
@@ -200,7 +200,7 @@ class Audit(ABC):
         if sum(dist) < 2 * tolerance:
             return [int(len(dist) / 2 - 1), int(len(dist) / 2 + 1)]
 
-        interval = [0, len(dist)]
+        interval = [0, len(dist) - 1]
         lower_sum = 0
         upper_sum = 0
 


### PR DESCRIPTION
current dist functions were occasionally getting index out of bounds
errors because the default interval in _get_interval() was 0 to length
instead of 0 to length - 1, meaning when the upper interval did not get
modified in _get_interval(), the index would be out of bounds.