### PR TITLE
Adding pairwise contests to fix the irrelevant ballot, multi candidate issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,25 @@ of risk-limiting audits.
 
 # Installation
 
+You can install the in-development version via:
 ```
-pip install r2b2
+git clone https://github.com/gwexploratoryaudits/r2b2.git
+pip install .
 ```
 
-You can also install the in-development version with:
-```
-pip install https://github.com/gwexploratoryaudits/r2b2/archive/master.zip
-```
+# Usage
+R2B2 provides both a Python module for programatic use via its API, and a command-line interface.
+
+Here are some command-line examples for getting interactive help and running audits:
+
+    r2b2 --help
+    r2b2 bulk --help
+    r2b2 bulk -l "50 100" src/r2b2/tests/data/basic_contest.json brla 0.1 0.1
+    r2b2 interactive -a minerva -r 0.1 -m 0.2 -v --contest-file src/r2b2/tests/data/basic_contest.json
 
 # Documentation
 
-[r2b2.readthedocs.io](https://r2b2.readthedocs.io/)
+The R2B2 API is documented at [r2b2.readthedocs.io](https://r2b2.readthedocs.io/).
 
 # Development
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ of risk-limiting audits.
 You can install the in-development version via:
 ```
 git clone https://github.com/gwexploratoryaudits/r2b2.git
+cd r2b2
 pip install .
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     install_requires=[
         # eg: 'aspectlib==1.1.1', 'six>=1.7',
-        'Click',
+        'click>=7',
         'numpy',
         'scipy',
         'typing',

--- a/src/r2b2/audit.py
+++ b/src/r2b2/audit.py
@@ -200,12 +200,12 @@ class Audit(ABC):
                 self.distribution_reported_tally = distribution_round_draw
 
     def truncate_dist_null(self):
-        """Truncate null distribution and update the stopping probability schedule."""
+        """Update the risk schedule and truncate the null distribution."""
         self.risk_schedule.append(sum(self.distribution_null[self.min_winner_ballots[-1]:]))
         self.distribution_null = self.distribution_null[:self.min_winner_ballots[-1]]
 
     def truncate_dist_reported(self):
-        """Truncate reported distribution and update the stopping probability schedule."""
+        """Update the stopping probability schedule and truncate the reported distribution."""
         self.stopping_prob_schedule.append(
             sum(self.distribution_reported_tally[self.min_winner_ballots[-1]:]))
         self.distribution_reported_tally = self.distribution_reported_tally[

--- a/src/r2b2/audit.py
+++ b/src/r2b2/audit.py
@@ -315,6 +315,14 @@ class Audit(ABC):
             self.current_dist_null()
             self.current_dist_reported()
 
+            while click.confirm('Would you like to enter a hypothetical number of votes for reported winner?'):
+                hypothetical_votes_for_winner = click.prompt(
+                    'Enter the hypothetical number of (total) reported winner votes in sample',
+                    type=click.IntRange(previous_votes_for_winner,
+                                        previous_votes_for_winner + (sample_size - prev_sample_size)))
+                hypothetical_pvalue = self.compute_risk(hypothetical_votes_for_winner, sample_size)
+                click.echo('{:<50}'.format('Hypothetical p-value: {}'.format(hypothetical_pvalue)))
+
             votes_for_winner = click.prompt('Enter total number of votes for reported winner found in sample',
                                             type=click.IntRange(previous_votes_for_winner,
                                                                 previous_votes_for_winner + (sample_size - prev_sample_size)))
@@ -348,6 +356,7 @@ class Audit(ABC):
         self.sample_winner_ballots = []
         self.risk_schedule = []
         self.stopping_prob_schedule = []
+        self.pvalue_schedule = []
         self.distribution_null = [1.0]
         self.distribution_reported_tally = [1.0]
 

--- a/src/r2b2/audit.py
+++ b/src/r2b2/audit.py
@@ -135,7 +135,8 @@ class Audit(ABC):
         beta_str = 'Beta: {}\n'.format(self.beta)
         max_frac_str = 'Maximum Fraction to Draw: {}\n'.format(self.max_fraction_to_draw)
         replacement_str = 'Replacement: {}\n\n'.format(self.replacement)
-        return title_str + alpha_str + beta_str + max_frac_str + replacement_str + str(self.contest)
+        pair_str = 'Pair: {}, {}\n'.format(self.pairwise_contest.reported_winner, self.pairwise_contest.reported_loser)
+        return title_str + alpha_str + beta_str + max_frac_str + replacement_str + str(self.contest) + pair_str
 
     def current_dist_null(self):
         """Update distribution_null for current round."""

--- a/src/r2b2/audit.py
+++ b/src/r2b2/audit.py
@@ -311,6 +311,9 @@ class Audit(ABC):
                                        type=click.IntRange(prev_sample_size + 1, max_sample_size))
             self.rounds.append(sample_size)
 
+            self.current_dist_null()
+            self.current_dist_reported()
+
             votes_for_winner = click.prompt('Enter total number of votes for reported winner found in sample',
                                             type=click.IntRange(previous_votes_for_winner,
                                                                 previous_votes_for_winner + (sample_size - prev_sample_size)))
@@ -329,9 +332,7 @@ class Audit(ABC):
 
             kmin = self.next_min_winner_ballots(sample_size)
             self.min_winner_ballots.append(kmin)
-            self.current_dist_null()
             self.truncate_dist_null()
-            self.current_dist_reported()
             self.truncate_dist_reported()
             previous_votes_for_winner = votes_for_winner
             self.sample_winner_ballots.append(votes_for_winner)

--- a/src/r2b2/audit.py
+++ b/src/r2b2/audit.py
@@ -95,6 +95,7 @@ class Audit(ABC):
         self.sample_winner_ballots = []
         self.risk_schedule = []
         self.stopping_prob_schedule = []
+        self.pvalue_schedule = []
         self.distribution_null = [1.0]
         self.distribution_reported_tally = [1.0]
 
@@ -401,6 +402,17 @@ class Audit(ABC):
 
         Returns:
             Current risk level of the audit (as defined per audit implementation).
+        """
+
+        pass
+
+    @abstractmethod
+    def get_risk_level(self, *args, **kwargs):
+        """Find the risk level of the audit, that is, the smallest risk limit for which the audit
+        as it has panned out would have already stopped.
+
+        Returns:
+            Risk level of the realization of the audit.
         """
 
         pass

--- a/src/r2b2/audit.py
+++ b/src/r2b2/audit.py
@@ -121,7 +121,7 @@ class Audit(ABC):
         return title_str + alpha_str + beta_str + max_frac_str + replacement_str + str(self.contest)
 
     def current_dist_null(self):
-        """Update distribution null and risk schedule for current round."""
+        """Update distribution_null for current round."""
 
         if len(self.rounds) == 1:
             round_draw = self.rounds[0]
@@ -161,7 +161,7 @@ class Audit(ABC):
                 self.distribution_null = distribution_round_draw
 
     def current_dist_reported(self):
-        """Update distribution_reported_tally and stopping probability schedule for round."""
+        """Update distribution_reported_tally for current round."""
 
         if len(self.rounds) == 1:
             round_draw = self.rounds[0]
@@ -296,7 +296,7 @@ class Audit(ABC):
                 click.echo('|{:<50}|'.format('Minimum Sample Size: {}'.format(self.min_sample_size)))
                 click.echo('|{:<50}|'.format('Maximum Sample Size: {}'.format(max_sample_size)))
                 click.echo('|{:50}|'.format(' '))
-                click.echo('|{:^16}|{:^16}|{:^16}|'.format('Round', 'Stopping Prob.', 'Risk'))
+                click.echo('|{:^16}|{:^16}|{:^16}|'.format('Round', 'Stopping Prob.', 'Risk Expended'))
                 click.echo('|----------------|----------------|----------------|')
                 for r in range(1, curr_round):
                     click.echo('|{:^16}|{:^16}|{:^16}|'.format(r, '{:.12f}'.format(self.stopping_prob_schedule[r - 1]),

--- a/src/r2b2/brla.py
+++ b/src/r2b2/brla.py
@@ -62,7 +62,8 @@ class BayesianRLA(Audit):
         title_str = 'BayesianRLA without replacement\n-------------------------------\n'
         alpha_str = 'Risk Limit: {}\n'.format(self.alpha)
         max_frac_str = 'Maximum Fraction to Draw: {}\n'.format(self.max_fraction_to_draw)
-        return title_str + alpha_str + max_frac_str + str(self.contest)
+        pair_str = 'Pair: {}, {}\n'.format(self.pairwise_contest.reported_winner, self.pairwise_contest.reported_loser)
+        return title_str + alpha_str + max_frac_str + str(self.contest) + pair_str
 
     def stopping_condition(self, votes_for_winner: int, verbose: bool = False) -> bool:
         if len(self.rounds) < 1:

--- a/src/r2b2/brla.py
+++ b/src/r2b2/brla.py
@@ -32,10 +32,10 @@ class BayesianRLA(Audit):
 
     prior: np.ndarray
 
-    def __init__(self, alpha: float, max_fraction_to_draw: float, contest: Contest):
+    def __init__(self, alpha: float, max_fraction_to_draw: float, contest: Contest, pair: List[str] = None):
         """Initialize a Bayesian RLA."""
 
-        super().__init__(alpha, 0.0, max_fraction_to_draw, False, contest)
+        super().__init__(alpha, 0.0, max_fraction_to_draw, False, contest, pair)
         self.prior = self.compute_prior()
         self.min_sample_size = self.get_min_sample_size()
 

--- a/src/r2b2/brla.py
+++ b/src/r2b2/brla.py
@@ -232,3 +232,6 @@ class BayesianRLA(Audit):
                 min_winner_ballots.append(current_kmin)
 
         return min_winner_ballots
+
+    def get_risk_level(self, *args, **kwargs):
+        pass

--- a/src/r2b2/cli.py
+++ b/src/r2b2/cli.py
@@ -27,6 +27,7 @@ from r2b2.brla import BayesianRLA as BRLA
 from r2b2.contest import Contest
 from r2b2.contest import ContestType
 from r2b2.election import Election
+from r2b2.minerva import Minerva
 from r2b2.tests import util
 
 
@@ -46,7 +47,7 @@ INT_LIST = IntList()
 
 # Audit type choices
 # TODO: add new audit types when they become available
-audit_types = click.Choice(['brla'], case_sensitive=False)
+audit_types = click.Choice(['brla', 'minerva'], case_sensitive=False)
 # Contest type choice
 contest_types = click.Choice(['PLURALITY', 'MAJORITY'])
 
@@ -318,6 +319,8 @@ def input_audit(contest: Contest, alpha: float = None, max_fraction_to_draw: flo
 
     if audit_type == 'brla':
         return BRLA(alpha, max_fraction_to_draw, contest)
+    elif audit_type == 'minerva':
+        return Minerva(alpha, max_fraction_to_draw, contest)
     # TODO: add creation for other types of audits.
     return None
 

--- a/src/r2b2/cli.py
+++ b/src/r2b2/cli.py
@@ -18,6 +18,7 @@ Note:
       Also see (1) from http://click.pocoo.org/5/setuptools/#setuptools-integration
 """
 import math
+from typing import Tuple
 
 import click
 import pkg_resources
@@ -79,6 +80,12 @@ def cli():
               type=click.FloatRange(0.0, 1.0),
               prompt='Enter maximum fraction of ballots to draw during audit',
               help='Maximum fraction of total contest ballots that could be drawn during the audit.')
+@click.option('-p',
+              '--pair',
+              type=str,
+              nargs=2,
+              default=None,
+              help='Pair of candidates from the contest to audit. Ordered reported winner, reported loser.')
 @click.option('-v',
               '--verbose',
               default=False,
@@ -86,7 +93,7 @@ def cli():
               flag_value=True,
               show_default=False,
               help='Provides risk and stopping probability schedule of previous rounds, minimum and  maximum sample size.')
-def interactive(election_mode, election_file, contest_file, audit_type, risk_limit, max_fraction_to_draw, verbose):
+def interactive(election_mode, election_file, contest_file, audit_type, risk_limit, max_fraction_to_draw, pair, verbose):
     """Executes an audit round by round.
 
     Depending on what options are passed to the interactive command, users may be prompted for
@@ -161,7 +168,7 @@ def interactive(election_mode, election_file, contest_file, audit_type, risk_lim
         click.echo(contest)
 
     # Create audit from prompted input
-    audit = input_audit(contest, risk_limit, max_fraction_to_draw, audit_type)
+    audit = input_audit(contest, risk_limit, max_fraction_to_draw, audit_type, pair)
     click.echo(audit)
     # Confirm audit, if incorrect get new audit
     while not click.confirm('\nAre the audit parameters correct?'):
@@ -305,7 +312,11 @@ def template(style, output):
         click.echo(template)
 
 
-def input_audit(contest: Contest, alpha: float = None, max_fraction_to_draw: float = None, audit_type: str = None) -> Audit:
+def input_audit(contest: Contest,
+                alpha: float = None,
+                max_fraction_to_draw: float = None,
+                audit_type: str = None,
+                pair: Tuple[str] = None) -> Audit:
     # Create an audit from user-input.
     click.echo('\nCreate a new Audit')
     click.echo('==================\n')
@@ -316,11 +327,22 @@ def input_audit(contest: Contest, alpha: float = None, max_fraction_to_draw: flo
         max_fraction_to_draw = click.prompt('Enter the maximum fraction of contest ballots to draw', type=click.FloatRange(0.0, 1.0))
     if audit_type is None:
         audit_type = click.prompt('Select an audit type', type=audit_types)
+    if pair == ():
+        pair = None
+    if pair is None:
+        if contest.num_candidates > 2 and click.confirm('Select a pair of candidates other than the top 2?'):
+            rw = click.prompt('Enter reported winner', type=click.Choice(contest.reported_winners))
+            other_candidates = contest.candidates.copy()
+            other_candidates.remove(rw)
+            rl = click.prompt('Enter reported loser', type=click.Choice(other_candidates))
+            pair = [rw, rl]
+    else:
+        pair = [pair[0], pair[1]]
 
     if audit_type == 'brla':
-        return BRLA(alpha, max_fraction_to_draw, contest)
+        return BRLA(alpha, max_fraction_to_draw, contest, pair)
     elif audit_type == 'minerva':
-        return Minerva(alpha, max_fraction_to_draw, contest)
+        return Minerva(alpha, max_fraction_to_draw, contest, pair)
     # TODO: add creation for other types of audits.
     return None
 

--- a/src/r2b2/contest.py
+++ b/src/r2b2/contest.py
@@ -120,6 +120,13 @@ class Contest:
                     self.sub_contests.append(PairwiseContest(rw, candidate, rw_ballots, self.tally[candidate]))
 
     def find_sub_contest(self, reported_winner, reported_loser):
+        if reported_winner not in self.reported_winners:
+            raise ValueError('reported winner must be a reported winner')
+        if reported_loser not in self.candidates:
+            raise ValueError('reported loser must be a candidate')
+        if reported_winner == reported_loser:
+            raise ValueError('reported winner and loser must be distinct candidates')
+
         for i in range(len(self.sub_contests)):
             if self.sub_contests[i].reported_winner == reported_winner and self.sub_contests[i].reported_loser == reported_loser:
                 return i

--- a/src/r2b2/minerva.py
+++ b/src/r2b2/minerva.py
@@ -31,8 +31,6 @@ class Minerva(Audit):
         """Initialize a Minerva audit."""
         super().__init__(alpha, 0.0, max_fraction_to_draw, True, contest)
         self.min_sample_size = self.get_min_sample_size()
-        self.rounds = []
-        self.min_winner_ballots = []
 
     def get_min_sample_size(self, min_sprob: float = 10 ** (-6)):
         """Computes the minimum sample size that has a stopping size (kmin). Here we find a
@@ -204,8 +202,13 @@ class Minerva(Audit):
             self.truncate_dist_null()
             self.truncate_dist_reported()
 
-    def compute_risk(self, *args, **kwargs):
-        pass
+    def compute_risk(self, votes_for_winner: int, *args, **kwargs):
+        """Return the hypothetical pvalue if votes_for_winner were obtained in the most recent
+        round."""
+
+        tail_null = sum(self.distribution_null[votes_for_winner:])
+        tail_reported = sum(self.distribution_reported_tally[votes_for_winner:])
+        return tail_null / tail_reported
 
     def get_risk_level(self):
         """Return the risk level of an interactive Minerva audit. Non-interactive and bulk Minerva

--- a/src/r2b2/minerva.py
+++ b/src/r2b2/minerva.py
@@ -27,9 +27,9 @@ class Minerva(Audit):
         contest (Contest): Contest to be audited.
     """
 
-    def __init__(self, alpha: float, max_fraction_to_draw: float, contest: Contest):
+    def __init__(self, alpha: float, max_fraction_to_draw: float, contest: Contest, pair: List[str] = None):
         """Initialize a Minerva audit."""
-        super().__init__(alpha, 0.0, max_fraction_to_draw, True, contest)
+        super().__init__(alpha, 0.0, max_fraction_to_draw, True, contest, pair)
         self.min_sample_size = self.get_min_sample_size()
 
     def get_min_sample_size(self, min_sprob: float = 10 ** (-6)):
@@ -44,9 +44,9 @@ class Minerva(Audit):
         """
 
         # p0 is not .5 for contests with odd total ballots.
-        p0 = (self.contest.contest_ballots // 2) / self.contest.contest_ballots
-        p1 = self.contest.winner_prop
-        max_sample_size = math.ceil(self.contest.contest_ballots * self.max_fraction_to_draw)
+        p0 = (self.pairwise_contest.contest_ballots // 2) / self.pairwise_contest.contest_ballots
+        p1 = self.pairwise_contest.winner_prop
+        max_sample_size = math.ceil(self.pairwise_contest.contest_ballots * self.max_fraction_to_draw)
 
         # There may not be a point n' such that all n >= n' are acceptable round sizes and all
         # n < n' are unacceptable round sizes.
@@ -121,7 +121,7 @@ class Minerva(Audit):
         for i in range(len(rounds)):
             if rounds[i] < self.min_sample_size:
                 raise ValueError('Sample size must be >= minimum sample size.')
-            if rounds[i] > self.contest.contest_ballots * self.max_fraction_to_draw:
+            if rounds[i] > self.pairwise_contest.contest_ballots * self.max_fraction_to_draw:
                 raise ValueError(
                     'Sample size cannot exceed the maximum fraction of contest ballots to draw.')
             if i >= 1 and rounds[i] <= rounds[i - 1]:
@@ -178,10 +178,10 @@ class Minerva(Audit):
         if len(self.rounds) > 0:
             raise Exception("This audit already has an (at least partial) round schedule.")
         if max_sample_size is None:
-            max_sample_size = math.ceil(self.contest.contest_ballots * self.max_fraction_to_draw)
+            max_sample_size = math.ceil(self.pairwise_contest.contest_ballots * self.max_fraction_to_draw)
         if max_sample_size < self.min_sample_size:
             raise ValueError("Maximum sample size must be greater than or equal to minimum size.")
-        if max_sample_size > self.contest.contest_ballots:
+        if max_sample_size > self.pairwise_contest.contest_ballots:
             raise ValueError("Maximum sample size cannot exceed total contest ballots.")
 
         for sample_size in range(self.min_sample_size, max_sample_size + 1):

--- a/src/r2b2/minerva.py
+++ b/src/r2b2/minerva.py
@@ -32,6 +32,7 @@ class Minerva(Audit):
         self.min_sample_size = self.get_min_sample_size()
         self.rounds = []
         self.min_winner_ballots = []
+        self.realized_risks = []
 
     def get_min_sample_size(self):
         """Computes the minimum sample size that has a stopping size (kmin).
@@ -63,6 +64,7 @@ class Minerva(Audit):
 
         if verbose:
             click.echo('\np-value: {}'.format(tail_null / tail_reported))
+        self.realized_risks.append(tail_null / tail_reported)
 
         return self.alpha * tail_reported > tail_null
 
@@ -77,7 +79,8 @@ class Minerva(Audit):
         the audit's minimum number of winner ballots schedule with the corresponding minimums to
         meet the stopping condition.
 
-        Args: rounds (List[int]): A (partial) round schedule of the audit.
+        Args:
+            rounds (List[int]): A (partial) round schedule of the audit.
         """
 
         if len(rounds) < 1:
@@ -104,7 +107,13 @@ class Minerva(Audit):
             self.truncate_dist_reported()
 
     def find_kmin(self, append: bool):
-        """Search for a kmin (minimum number of winner ballots) satisfying all stopping criteria."""
+        """Search for a kmin (minimum number of winner ballots) satisfying all stopping criteria.
+
+        Args:
+            append (bool): Optionally append the kmins to the min_winner_ballots list. This may
+            not always be desirable here because, for example, appending happens automatically
+            outside this method during an interactive audit.
+        """
 
         for possible_kmin in range(self.rounds[-1] // 2 + 1, len(self.distribution_null)):
             tail_null = sum(self.distribution_null[possible_kmin:])
@@ -121,10 +130,55 @@ class Minerva(Audit):
             self.min_winner_ballots.append(None)
         return None
 
-    def compute_all_min_winner_ballots(self, *args, **kwargs):
-        pass
+    def compute_all_min_winner_ballots(self, max_sample_size: int = None, *args, **kwargs):
+        """Compute the minimum number of winner ballots for the complete (that is, ballot-by-ballot)
+        round schedule. Note that Minerva ballot-by-ballot is equivalent to the BRAVO audit.
+
+        Note: Due to limited convolutional precision, results may be off somewhat after the
+        stopping probability very nearly equals 1.
+
+        Args:
+            max_sample_size (int): Optionally set the maximum sample size to generate stopping sizes
+            (kmins) up to. If not provided the maximum sample size is determined by max_frac_to_draw
+            and the total contest ballots.
+
+        Returns:
+            None, kmins are appended to the min_winner_ballots list.
+        """
+
+        if len(self.rounds) > 0:
+            raise Exception("This audit already has an (at least partial) round schedule.")
+        if max_sample_size is None:
+            max_sample_size = math.ceil(self.contest.contest_ballots * self.max_fraction_to_draw)
+        if max_sample_size < self.min_sample_size:
+            raise ValueError("Maximum sample size must be greater than or equal to minimum size.")
+        if max_sample_size > self.contest.contest_ballots:
+            raise ValueError("Maximum sample size cannot exceed total contest ballots.")
+
+        for sample_size in range(self.min_sample_size, max_sample_size + 1):
+            self.rounds.append(sample_size)
+            self.current_dist_null()
+            self.current_dist_reported()
+            # First kmin computed directly.
+            if sample_size == self.min_sample_size:
+                current_kmin = self.find_kmin(True)
+            else:
+                tail_null = sum(self.distribution_null[current_kmin:])
+                tail_reported = sum(self.distribution_reported_tally[current_kmin:])
+                if self.alpha * tail_reported > tail_null:
+                    self.min_winner_ballots.append(current_kmin)
+                else:
+                    current_kmin += 1
+                    self.min_winner_ballots.append(current_kmin)
+            self.truncate_dist_null()
+            self.truncate_dist_reported()
 
     def compute_risk(self, *args, **kwargs):
-        # NOTE: For interactive: minimum of 1/ratio (where numerator is realized ballots for winner)
-        # schedule. For non-interactive/bulk: possibly the same?. No ratio schedule field here yet.
-        pass
+        """Return the current risk level of an interactive Minerva audit. Non-interactive and bulk
+        Minerva audits are not considered here since the sampled number of reported winner ballots
+        is not available.
+        """
+
+        if len(self.realized_risks) < 1:
+            return None
+        return min(self.realized_risks)

--- a/src/r2b2/sprob.py
+++ b/src/r2b2/sprob.py
@@ -69,10 +69,10 @@ class Sprob():
         p = self.contest.winner_prop
         if round_index == 0:
             n = self.rounds[round_index]
-            self.distribution = binom.pmf(range(0, n + 1), n, p)
+            self.distribution = binom.pmf(range(n+1), n, p)
         else:
             n = self.rounds[round_index] - self.rounds[round_index - 1]
-            self.distribution = fftconvolve(self.distribution, binom.pmf(range(0, n + 1), n, p))
+            self.distribution = fftconvolve(self.distribution, binom.pmf(range(n+1), n, p))
 
     def truncate_dist(self, round_index):
         """Sums and truncates the distribution at the kmin."""

--- a/src/r2b2/sprob.py
+++ b/src/r2b2/sprob.py
@@ -1,0 +1,89 @@
+"""Stopping probability module."""
+from typing import List
+
+from scipy.signal import fftconvolve
+from scipy.stats import binom
+
+from r2b2.contest import Contest
+
+
+class Sprob():
+    """Stopping probability functionality implementation.
+
+    Audits can be represented as a sequence of increasing round sizes and kmins. This module takes
+    those lists and computes the stopping probabilities (or risks) for the audit. There may be a
+    discrepancy between an audit's self-reported stopping probabilities and the stopping probabilities
+    computed here. This can be the result of an audit scheme incorporating conservative assumptions
+    (e.g., a ballot-by-ballot decision) that are not applicable to the round schedule at hand.
+
+    This module does not generate kmins from scratch, and so is not a subclass of Audit. This module
+    assumes ballots are drawn with replacement.
+
+    The stopping probabilities reported are non-cumulative.
+
+    Attributes:
+        rounds (List[int]): Cumulative round schedule.
+        min_winner_ballots (List[int]): Stopping sizes (or kmins) respective to the round schedule.
+        contest (Contest): Contest to be audited.
+    """
+
+    def __init__(self, rounds: List[int], min_winner_ballots: List[int], contest: Contest):
+        self.rounds = rounds
+        self.min_winner_ballots = min_winner_ballots
+        self.contest = contest
+
+        self.distribution = []
+
+        self.sprobs = []
+
+    def compute_sprobs(self):
+        """Returns an array non-cumulative stopping probabilities, respective to the rounds."""
+
+        if len(self.rounds) < 1:
+            raise Exception("Round schedule must contain at least 1 round.")
+        if len(self.rounds) != len(self.min_winner_ballots):
+            raise Exception("Round and kmin schedules must have the same length.")
+        if self.rounds[0] < 1:
+            raise ValueError("Round sizes must be >= 1.")
+        if self.min_winner_ballots[0] < 1:
+            raise ValueError("Kmins must be >= 1.")
+        if self.min_winner_ballots[0] > self.rounds[0]:
+            raise ValueError("Kmins cannot exceed respective round sizes.")
+        for i in range(1, len(self.rounds)):
+            if self.rounds[i] <= self.rounds[i-1]:
+                raise ValueError("Round schedule must strictly increase.")
+            if self.min_winner_ballots[i] > self.rounds[i]:
+                raise ValueError("Kmins cannot exceed respective round sizes.")
+
+        self.sprobs = []
+
+        for i in range(len(self.rounds)):
+            self.current_dist(i)
+            self.truncate_dist(i)
+
+        return self.sprobs
+
+    def current_dist(self, round_index):
+        """Generates the current round distribution: a binomial for the first round and a convolution
+        of a binomial and a quasi-binomial thereafter."""
+        p = self.contest.winner_prop
+        if round_index == 0:
+            n = self.rounds[round_index]
+            self.distribution = binom.pmf(range(0, n + 1), n, p)
+        else:
+            n = self.rounds[round_index] - self.rounds[round_index - 1]
+            self.distribution = fftconvolve(self.distribution, binom.pmf(range(0, n + 1), n, p))
+
+    def truncate_dist(self, round_index):
+        """Sums and truncates the distribution at the kmin."""
+        self.sprobs.append(sum(self.distribution[self.min_winner_ballots[round_index]:]))
+        self.distribution = self.distribution[:self.min_winner_ballots[round_index]]
+
+    def expectation(self):
+        """Returns the average number of ballots audited under the given schedule of round sizes
+        and kmins."""
+        if len(self.sprobs) != len(self.rounds):
+            self.compute_sprobs
+
+        return (sum([self.rounds[i] * self.sprobs[i] for i in range(len(self.rounds))]) +
+                (1 - sum(self.sprobs)) * self.contest.contest_ballots)

--- a/src/r2b2/sprob.py
+++ b/src/r2b2/sprob.py
@@ -48,11 +48,11 @@ class Sprob():
         if self.min_winner_ballots[0] < 1:
             raise ValueError("Kmins must be >= 1.")
         if self.min_winner_ballots[0] > self.rounds[0]:
-            raise ValueError("Kmins cannot exceed respective round sizes.")
+            raise ValueError("Kmins cannot exceed respective round sizes; first kmin must exist.")
         for i in range(1, len(self.rounds)):
             if self.rounds[i] <= self.rounds[i-1]:
                 raise ValueError("Round schedule must strictly increase.")
-            if self.min_winner_ballots[i] > self.rounds[i]:
+            if self.min_winner_ballots[i] is not None and self.min_winner_ballots[i] > self.rounds[i]:
                 raise ValueError("Kmins cannot exceed respective round sizes.")
 
         self.sprobs = []
@@ -76,6 +76,10 @@ class Sprob():
 
     def truncate_dist(self, round_index):
         """Sums and truncates the distribution at the kmin."""
+        # Support for some sentinels.
+        if self.min_winner_ballots[round_index] is None or self.min_winner_ballots[round_index] < 1:
+            self.sprobs.append(0)
+            return
         self.sprobs.append(sum(self.distribution[self.min_winner_ballots[round_index]:]))
         self.distribution = self.distribution[:self.min_winner_ballots[round_index]]
 

--- a/src/r2b2/tests/data/cli_test_expected_out_compute_risk_minerva.txt
+++ b/src/r2b2/tests/data/cli_test_expected_out_compute_risk_minerva.txt
@@ -65,38 +65,11 @@ Beginning Audit...
 ----------
 
 Enter next sample size (as a running total): 100
+Would you like to enter a hypothetical number of votes for reported winner? [y/N]: y
+Enter the hypothetical number of (total) reported winner votes in sample: 57
+Hypothetical p-value: 0.1266246240013251          
 Would you like to enter a hypothetical number of votes for reported winner? [y/N]: n
-Enter total number of votes for reported winner found in sample: 57
-
-
-+----------------------------------------+
-|     Stopping Condition Met? False      |
-+----------------------------------------+
-
-Would you like to force stop the audit [y/N]: n
-
-----------
- Round 2  
-----------
-
-Enter next sample size (as a running total): 200
-Would you like to enter a hypothetical number of votes for reported winner? [y/N]: n
-Enter total number of votes for reported winner found in sample: 112
-
-
-+----------------------------------------+
-|     Stopping Condition Met? False      |
-+----------------------------------------+
-
-Would you like to force stop the audit [y/N]: n
-
-----------
- Round 3  
-----------
-
-Enter next sample size (as a running total): 400
-Would you like to enter a hypothetical number of votes for reported winner? [y/N]: n
-Enter total number of votes for reported winner found in sample: 221
+Enter total number of votes for reported winner found in sample: 60
 
 
 +----------------------------------------+

--- a/src/r2b2/tests/data/cli_test_expected_out_compute_risk_minerva.txt
+++ b/src/r2b2/tests/data/cli_test_expected_out_compute_risk_minerva.txt
@@ -51,6 +51,7 @@ Reported Tallies:
 Reported Winners: ['A']
 Contest Type: ContestType.MAJORITY
 
+Pair: A, B
 
 
 Are the audit parameters correct? [y/N]: y

--- a/src/r2b2/tests/data/cli_test_expected_out_interactive.txt
+++ b/src/r2b2/tests/data/cli_test_expected_out_interactive.txt
@@ -1,7 +1,7 @@
 
 Welcome to the R2B2 auditing tool!
 
-Select an audit type (brla): brla
+Select an audit type (brla, minerva): brla
 Enter desired risk limit (e.g. use 0.1 for 10%): 0.1
 Enter maximum fraction of ballots to draw during audit: 0.2
 

--- a/src/r2b2/tests/data/cli_test_expected_out_interactive.txt
+++ b/src/r2b2/tests/data/cli_test_expected_out_interactive.txt
@@ -48,6 +48,7 @@ Reported Tallies:
 Reported Winners: ['A']
 Contest Type: ContestType.PLURALITY
 
+Pair: A, B
 
 
 Are the audit parameters correct? [y/N]: y

--- a/src/r2b2/tests/data/cli_test_expected_out_interactive.txt
+++ b/src/r2b2/tests/data/cli_test_expected_out_interactive.txt
@@ -62,6 +62,7 @@ Beginning Audit...
 ----------
 
 Enter next sample size (as a running total): 200
+Would you like to enter a hypothetical number of votes for reported winner? [y/N]: n
 Enter total number of votes for reported winner found in sample: 175
 
 

--- a/src/r2b2/tests/data/cli_test_expected_out_interactive_given_audit.txt
+++ b/src/r2b2/tests/data/cli_test_expected_out_interactive_given_audit.txt
@@ -45,6 +45,7 @@ Reported Tallies:
 Reported Winners: ['A']
 Contest Type: ContestType.PLURALITY
 
+Pair: A, B
 
 
 Are the audit parameters correct? [y/N]: y

--- a/src/r2b2/tests/data/cli_test_expected_out_interactive_given_audit.txt
+++ b/src/r2b2/tests/data/cli_test_expected_out_interactive_given_audit.txt
@@ -59,6 +59,7 @@ Beginning Audit...
 ----------
 
 Enter next sample size (as a running total): 200
+Would you like to enter a hypothetical number of votes for reported winner? [y/N]: n
 Enter total number of votes for reported winner found in sample: 175
 
 

--- a/src/r2b2/tests/data/cli_test_expected_out_interactive_given_both.txt
+++ b/src/r2b2/tests/data/cli_test_expected_out_interactive_given_both.txt
@@ -46,6 +46,7 @@ Beginning Audit...
 ----------
 
 Enter next sample size (as a running total): 20
+Would you like to enter a hypothetical number of votes for reported winner? [y/N]: n
 Enter total number of votes for reported winner found in sample: 19
 
 

--- a/src/r2b2/tests/data/cli_test_expected_out_interactive_given_both.txt
+++ b/src/r2b2/tests/data/cli_test_expected_out_interactive_given_both.txt
@@ -32,6 +32,7 @@ Reported Tallies:
 Reported Winners: ['CandidateA']
 Contest Type: ContestType.PLURALITY
 
+Pair: CandidateA, CandidateB
 
 
 Are the audit parameters correct? [y/N]: y

--- a/src/r2b2/tests/data/cli_test_expected_out_interactive_given_both.txt
+++ b/src/r2b2/tests/data/cli_test_expected_out_interactive_given_both.txt
@@ -7,8 +7,8 @@ Contest
 -------
 Contest Ballots: 100
 Reported Tallies:
-     CandidateA      50
-     CandidateB      50
+     CandidateA      60
+     CandidateB      40
 Reported Winners: ['CandidateA']
 Contest Type: ContestType.PLURALITY
 
@@ -27,8 +27,8 @@ Contest
 -------
 Contest Ballots: 100
 Reported Tallies:
-     CandidateA      50
-     CandidateB      50
+     CandidateA      60
+     CandidateB      40
 Reported Winners: ['CandidateA']
 Contest Type: ContestType.PLURALITY
 

--- a/src/r2b2/tests/data/cli_test_expected_out_interactive_given_contest.txt
+++ b/src/r2b2/tests/data/cli_test_expected_out_interactive_given_contest.txt
@@ -1,7 +1,7 @@
 
 Welcome to the R2B2 auditing tool!
 
-Select an audit type (brla): brla
+Select an audit type (brla, minerva): brla
 Enter desired risk limit (e.g. use 0.1 for 10%): 0.1
 Enter maximum fraction of ballots to draw during audit: 0.2
 

--- a/src/r2b2/tests/data/cli_test_expected_out_interactive_given_contest.txt
+++ b/src/r2b2/tests/data/cli_test_expected_out_interactive_given_contest.txt
@@ -10,8 +10,8 @@ Contest
 -------
 Contest Ballots: 100
 Reported Tallies:
-     CandidateA      50
-     CandidateB      50
+     CandidateA      60
+     CandidateB      40
 Reported Winners: ['CandidateA']
 Contest Type: ContestType.PLURALITY
 
@@ -30,8 +30,8 @@ Contest
 -------
 Contest Ballots: 100
 Reported Tallies:
-     CandidateA      50
-     CandidateB      50
+     CandidateA      60
+     CandidateB      40
 Reported Winners: ['CandidateA']
 Contest Type: ContestType.PLURALITY
 

--- a/src/r2b2/tests/data/cli_test_expected_out_interactive_given_contest.txt
+++ b/src/r2b2/tests/data/cli_test_expected_out_interactive_given_contest.txt
@@ -49,6 +49,7 @@ Beginning Audit...
 ----------
 
 Enter next sample size (as a running total): 20
+Would you like to enter a hypothetical number of votes for reported winner? [y/N]: n
 Enter total number of votes for reported winner found in sample: 19
 
 

--- a/src/r2b2/tests/data/cli_test_expected_out_interactive_given_contest.txt
+++ b/src/r2b2/tests/data/cli_test_expected_out_interactive_given_contest.txt
@@ -35,6 +35,7 @@ Reported Tallies:
 Reported Winners: ['CandidateA']
 Contest Type: ContestType.PLURALITY
 
+Pair: CandidateA, CandidateB
 
 
 Are the audit parameters correct? [y/N]: y

--- a/src/r2b2/tests/data/cli_test_expected_out_interactive_minerva.txt
+++ b/src/r2b2/tests/data/cli_test_expected_out_interactive_minerva.txt
@@ -1,0 +1,104 @@
+
+Welcome to the R2B2 auditing tool!
+
+Select an audit type (brla, minerva): minerva
+Enter desired risk limit (e.g. use 0.1 for 10%): 0.1
+Enter maximum fraction of ballots to draw during audit: 0.1
+
+Create a new Contest
+====================
+
+Enter number of contest ballots: 100000
+Enter number of candidates: 2
+Enter candidate name: A
+Enter number of votes reported for A: 60000
+Enter candidate name: B
+Enter number of votes reported for B: 40000
+Enter number of winners: 1
+Enter winner name (A, B): A
+Select contest type (PLURALITY, MAJORITY): MAJORITY
+
+
+Contest
+-------
+Contest Ballots: 100000
+Reported Tallies:
+     A               60000
+     B               40000
+Reported Winners: ['A']
+Contest Type: ContestType.MAJORITY
+
+
+
+Use the above contest data? [y/N]: y
+
+Create a new Audit
+==================
+
+Audit
+-----
+Alpha: 0.1
+Beta: 0.0
+Maximum Fraction to Draw: 0.1
+Replacement: True
+
+Contest
+-------
+Contest Ballots: 100000
+Reported Tallies:
+     A               60000
+     B               40000
+Reported Winners: ['A']
+Contest Type: ContestType.MAJORITY
+
+
+
+Are the audit parameters correct? [y/N]: y
+
+==================
+Beginning Audit...
+==================
+
+
+----------
+ Round 1  
+----------
+
+Enter next sample size (as a running total): 100
+Enter total number of votes for reported winner found in sample: 57
+
+
++----------------------------------------+
+|     Stopping Condition Met? False      |
++----------------------------------------+
+
+Would you like to force stop the audit [y/N]: n
+
+----------
+ Round 2  
+----------
+
+Enter next sample size (as a running total): 200
+Enter total number of votes for reported winner found in sample: 112
+
+
++----------------------------------------+
+|     Stopping Condition Met? False      |
++----------------------------------------+
+
+Would you like to force stop the audit [y/N]: n
+
+----------
+ Round 3  
+----------
+
+Enter next sample size (as a running total): 400
+Enter total number of votes for reported winner found in sample: 221
+
+
++----------------------------------------+
+|      Stopping Condition Met? True      |
++----------------------------------------+
+
+
+Audit Complete.

--- a/src/r2b2/tests/data/cli_test_expected_out_interactive_minerva.txt
+++ b/src/r2b2/tests/data/cli_test_expected_out_interactive_minerva.txt
@@ -51,6 +51,7 @@ Reported Tallies:
 Reported Winners: ['A']
 Contest Type: ContestType.MAJORITY
 
+Pair: A, B
 
 
 Are the audit parameters correct? [y/N]: y

--- a/src/r2b2/tests/data/cli_test_expected_out_interactive_multiround_.txt
+++ b/src/r2b2/tests/data/cli_test_expected_out_interactive_multiround_.txt
@@ -46,6 +46,7 @@ Beginning Audit...
 ----------
 
 Enter next sample size (as a running total): 100
+Would you like to enter a hypothetical number of votes for reported winner? [y/N]: n
 Enter total number of votes for reported winner found in sample: 63
 
 
@@ -60,6 +61,7 @@ Would you like to force stop the audit [y/N]: n
 ----------
 
 Enter next sample size (as a running total): 200
+Would you like to enter a hypothetical number of votes for reported winner? [y/N]: n
 Enter total number of votes for reported winner found in sample: 119
 
 
@@ -74,6 +76,7 @@ Would you like to force stop the audit [y/N]: n
 ----------
 
 Enter next sample size (as a running total): 300
+Would you like to enter a hypothetical number of votes for reported winner? [y/N]: n
 Enter total number of votes for reported winner found in sample: 175
 
 

--- a/src/r2b2/tests/data/cli_test_expected_out_interactive_multiround_.txt
+++ b/src/r2b2/tests/data/cli_test_expected_out_interactive_multiround_.txt
@@ -32,6 +32,7 @@ Reported Tallies:
 Reported Winners: ['CandidateA']
 Contest Type: ContestType.PLURALITY
 
+Pair: CandidateA, CandidateB
 
 
 Are the audit parameters correct? [y/N]: y

--- a/src/r2b2/tests/data/single_contest_template.json
+++ b/src/r2b2/tests/data/single_contest_template.json
@@ -1,8 +1,8 @@
 {
         "contest_ballots" : 100,
         "tally" : {
-                "CandidateA" : 50,
-                "CandidateB" : 50
+                "CandidateA" : 60,
+                "CandidateB" : 40
         },
         "num_winners" : 1,
         "reported_winners" : ["CandidateA"],

--- a/src/r2b2/tests/test_audit.py
+++ b/src/r2b2/tests/test_audit.py
@@ -12,8 +12,8 @@ default_contest = util.generate_contest(100)
 
 class SimpleAudit(Audit):
     """For testing purposes only."""
-    def __init__(self, alpha: float, beta: float, max_fraction_to_draw: int, replacement: bool, contest: Contest):
-        super().__init__(alpha, beta, max_fraction_to_draw, replacement, contest)
+    def __init__(self, alpha: float, beta: float, max_fraction_to_draw: int, replacement: bool, contest: Contest, pair=None):
+        super().__init__(alpha, beta, max_fraction_to_draw, replacement, contest, pair)
 
     def get_min_sample_size(self):
         return 5
@@ -158,6 +158,14 @@ def test_initialization_errors():
         SimpleAudit(0.1, 0.05, -0.1, True, default_contest)
     with pytest.raises(ValueError):
         SimpleAudit(0.1, 0.05, 1.5, True, default_contest)
+    # pair length
+    with pytest.raises(ValueError):
+        SimpleAudit(0.1, 0.05, 0.1, True, default_contest, ['a'])
+    with pytest.raises(ValueError):
+        SimpleAudit(0.1, 0.05, 0.1, True, default_contest, ['a', 'b', 'c'])
+    # pair type
+    with pytest.raises(TypeError):
+        SimpleAudit(0.1, 0.05, 0.1, True, default_contest, ['a', 1])
 
 
 def test_asn():

--- a/src/r2b2/tests/test_audit.py
+++ b/src/r2b2/tests/test_audit.py
@@ -36,6 +36,9 @@ class SimpleAudit(Audit):
     def compute_all_min_winner_ballots(self):
         return [1, 2, 3, 4]
 
+    def get_risk_level(self):
+        pass
+
 
 def test_simple_audit():
     """Tests creation of a basic Audit object."""

--- a/src/r2b2/tests/test_audit.py
+++ b/src/r2b2/tests/test_audit.py
@@ -104,6 +104,7 @@ def test_str():
     audit_str = 'Audit\n-----\nAlpha: 0.1\nBeta: 0.05\n'
     audit_str += 'Maximum Fraction to Draw: 0.1\nReplacement: True\n\n'
     audit_str += str(simpleaudit1.contest)
+    audit_str += 'Pair: a, b\n'
     assert str(simpleaudit1) == audit_str
 
 

--- a/src/r2b2/tests/test_brla.py
+++ b/src/r2b2/tests/test_brla.py
@@ -28,6 +28,7 @@ def test_str():
     brla_str = 'BayesianRLA without replacement\n-------------------------------\n'
     brla_str += 'Risk Limit: 0.1\nMaximum Fraction to Draw: 0.2\n'
     brla_str += str(default_contest)
+    brla_str += 'Pair: a, b\n'
     assert str(simplebrla) == brla_str
 
 

--- a/src/r2b2/tests/test_cli.py
+++ b/src/r2b2/tests/test_cli.py
@@ -17,7 +17,7 @@ def test_interactive_simple():
     The audit should run and stop in the first round.
     """
     runner = CliRunner()
-    user_in = 'brla\n0.1\n0.2\n1000\n2\nA\n700\nB\n300\n1\nA\nPLURALITY\ny\ny\n200\n175\n'
+    user_in = 'brla\n0.1\n0.2\n1000\n2\nA\n700\nB\n300\n1\nA\nPLURALITY\ny\ny\n200\nn\n175\n'
     result = runner.invoke(cli, 'interactive', input=user_in)
     output_file = open('src/r2b2/tests/data/cli_test_expected_out_interactive.txt', 'r')
     expected_out = output_file.read()
@@ -32,7 +32,7 @@ def test_interactive_given_audit():
     as cli option arguments. The audit should run and stop in the first round.
     """
     runner = CliRunner()
-    user_in = '1000\n2\nA\n700\nB\n300\n1\nA\nPLURALITY\ny\ny\n200\n175\n'
+    user_in = '1000\n2\nA\n700\nB\n300\n1\nA\nPLURALITY\ny\ny\n200\nn\n175\n'
     result = runner.invoke(cli, 'interactive -a brla -r 0.1 -m 0.2', input=user_in)
     output_file = open('src/r2b2/tests/data/cli_test_expected_out_interactive_given_audit.txt', 'r')
     expected_out = output_file.read()
@@ -47,7 +47,7 @@ def test_interactive_given_contest():
     The audit should run and stop in the first round.
     """
     runner = CliRunner()
-    user_in = 'brla\n0.1\n0.2\ny\ny\n20\n19\n'
+    user_in = 'brla\n0.1\n0.2\ny\ny\n20\nn\n19\n'
     result = runner.invoke(cli, 'interactive --contest-file=src/r2b2/tests/data/single_contest_template.json', input=user_in)
     output_file = open('src/r2b2/tests/data/cli_test_expected_out_interactive_given_contest.txt', 'r')
     expected_out = output_file.read()
@@ -62,7 +62,7 @@ def test_interactive_given_both():
     arguments. The audit should run and stop in the first round.
     """
     runner = CliRunner()
-    user_in = 'y\ny\n20\n19\n'
+    user_in = 'y\ny\n20\nn\n19\n'
     result = runner.invoke(cli,
                            'interactive -a brla -r 0.1 -m 0.2 --contest-file src/r2b2/tests/data/single_contest_template.json',
                            input=user_in)
@@ -76,7 +76,7 @@ def test_interactive_multi_round():
     """Testing `r2b2 interactive -a blra -r 0.1 -m 0.1 --contest-file=/.../basic_contest.json`"""
 
     runner = CliRunner()
-    user_in = 'y\ny\n100\n63\nn\n200\n119\nn\n300\n175\n'
+    user_in = 'y\ny\n100\nn\n63\nn\n200\nn\n119\nn\n300\nn\n175\n'
     result = runner.invoke(cli, 'interactive --contest-file src/r2b2/tests/data/basic_contest.json -a brla -r 0.1 -m 0.1', input=user_in)
     output_file = open('src/r2b2/tests/data/cli_test_expected_out_interactive_multiround_.txt', 'r')
     expected_out = output_file.read()

--- a/src/r2b2/tests/test_contest.py
+++ b/src/r2b2/tests/test_contest.py
@@ -35,7 +35,12 @@ def test_sorting_tally():
 
 def test_pairwise_sub_contests():
     contest = Contest(100, {'a': 50, 'b': 20, 'c': 10, 'd': 10, 'e': 5}, 1, ['a'], ContestType.PLURALITY)
-    assert contest.sub_contests == {'a': {'b': [50, 20, 70], 'c': [50, 10, 60], 'd': [50, 10, 60], 'e': [50, 5, 55]}}
+    assert len(contest.sub_contests) == 4
+    for i in range(4):
+        assert contest.sub_contests[i].reported_winner == 'a'
+        assert contest.sub_contests[i].reported_loser in ['b', 'c', 'd', 'e']
+        assert contest.sub_contests[i].reported_winner_ballots == 50
+        assert contest.sub_contests[i].reported_loser_ballots == contest.tally[contest.sub_contests[i].reported_loser]
 
 
 def test_repr():

--- a/src/r2b2/tests/test_contest.py
+++ b/src/r2b2/tests/test_contest.py
@@ -19,6 +19,25 @@ def test_simple_contest():
     assert simplecontest.winner_prop == 0.6
 
 
+def test_sorting_tally():
+    """Tests creation of a contest will sort the candidate tally before storing."""
+    contest1 = Contest(100, {'a': 10, 'b': 40, 'c': 50}, 1, ['c'], ContestType.PLURALITY)
+    assert contest1.candidates[0] == 'c'
+    assert contest1.candidates[1] == 'b'
+    assert contest1.candidates[2] == 'a'
+    contest2 = Contest(100, {'a': 40, 'b': 10, 'c': 30}, 2, ['c', 'a'], ContestType.PLURALITY)
+    assert contest2.candidates[0] == 'a'
+    assert contest2.candidates[1] == 'c'
+    assert contest2.candidates[2] == 'b'
+    assert contest2.reported_winners[0] == 'a'
+    assert contest2.reported_winners[1] == 'c'
+
+
+def test_pairwise_sub_contests():
+    contest = Contest(100, {'a': 50, 'b': 20, 'c': 10, 'd': 10, 'e': 5}, 1, ['a'], ContestType.PLURALITY)
+    assert contest.sub_contests == {'a': {'b': [50, 20, 70], 'c': [50, 10, 60], 'd': [50, 10, 60], 'e': [50, 5, 55]}}
+
+
 def test_repr():
     """Tests __repr__ function."""
     simplecontest1 = Contest(100, {'a': 60, 'b': 40}, 1, ['a'], ContestType.PLURALITY)

--- a/src/r2b2/tests/test_contest.py
+++ b/src/r2b2/tests/test_contest.py
@@ -41,6 +41,14 @@ def test_pairwise_sub_contests():
         assert contest.sub_contests[i].reported_loser in ['b', 'c', 'd', 'e']
         assert contest.sub_contests[i].reported_winner_ballots == 50
         assert contest.sub_contests[i].reported_loser_ballots == contest.tally[contest.sub_contests[i].reported_loser]
+    for rl in ['b', 'c', 'd', 'e']:
+        assert contest.find_sub_contest('a', rl) > -1
+    multi_winner = Contest(100, {'a': 40, 'b': 50, 'c': 10}, 2, ['a', 'b'], ContestType.PLURALITY)
+    assert len(multi_winner.sub_contests) == 3
+    assert multi_winner.find_sub_contest('a', 'b') == -1
+    assert multi_winner.find_sub_contest('a', 'c') > -1
+    assert multi_winner.find_sub_contest('b', 'a') > -1
+    assert multi_winner.find_sub_contest('b', 'c') > -1
 
 
 def test_repr():
@@ -126,3 +134,15 @@ def test_initialization_errors():
         Contest(100, tally, 1, win, 'PLURALITY')
     with pytest.raises(TypeError):
         Contest(100, tally, 1, win, None)
+
+
+def test_sub_contest_errors():
+    """Test exceptions raised correctly by find_sub_contest()"""
+    contest = Contest(100, {'a': 50, 'b': 20, 'c': 10, 'd': 10, 'e': 5}, 1, ['a'], ContestType.PLURALITY)
+    for rw in ['b', 'c', 'd', 'e']:
+        with pytest.raises(ValueError):
+            contest.find_sub_contest(rw, 'a')
+    with pytest.raises(ValueError):
+        contest.find_sub_contest('a', 'x')
+    with pytest.raises(ValueError):
+        contest.find_sub_contest('a', 'a')

--- a/src/r2b2/tests/test_minerva.py
+++ b/src/r2b2/tests/test_minerva.py
@@ -3,11 +3,11 @@ import math
 import pytest
 from click.testing import CliRunner
 
-import r2b2.tests.util as util
 from r2b2.cli import cli
 from r2b2.contest import Contest
 from r2b2.contest import ContestType
 from r2b2.minerva import Minerva
+import r2b2.tests.util as util
 
 default_contest = util.generate_contest(100000)
 
@@ -29,10 +29,9 @@ def test_min_sample_size():
     contest3 = Contest(100000, {'A': 51000, 'B': 49000}, 1, ['A'], ContestType.MAJORITY)
     minerva3 = Minerva(.05, .05, contest3)
 
-    # Numbers x below satisfy: (p1 / p0)^x > 1 / alpha yet (p1 / p0)^(x-1) <= 1 / alpha.
     assert minerva1.min_sample_size == 13
     assert minerva2.min_sample_size == 5
-    assert minerva3.min_sample_size == 152
+    assert minerva3.min_sample_size == 830
 
 
 def test_minerva_kmins():

--- a/src/r2b2/tests/test_minerva.py
+++ b/src/r2b2/tests/test_minerva.py
@@ -1,4 +1,8 @@
+import pytest
+from click.testing import CliRunner
+
 import r2b2.tests.util as util
+from r2b2.cli import cli
 from r2b2.contest import Contest
 from r2b2.contest import ContestType
 from r2b2.minerva import Minerva
@@ -33,6 +37,48 @@ def test_minerva_kmins():
     contest = Contest(100000, {'A': 60000, 'B': 40000}, 1, ['A'], ContestType.MAJORITY)
     minerva = Minerva(.1, .1, contest)
     minerva.compute_min_winner_ballots([100, 200, 400])
+
+    # From existing software
     assert minerva.min_winner_ballots == [58, 113, 221]
 
-# TODO: Test Minerva errors.
+
+def test_interactive_minerva():
+    runner = CliRunner()
+    user_in = 'minerva\n0.1\n0.1\n100000\n2\nA\n60000\nB\n40000\n1\nA\nMAJORITY\ny\ny\n100\n57\nn\n200\n112\nn\n400\n221\n'
+    result = runner.invoke(cli, 'interactive', input=user_in)
+    output_file = open('src/r2b2/tests/data/cli_test_expected_out_interactive_minerva.txt', 'r')
+    expected_out = output_file.read()
+    assert result.output == expected_out
+    output_file.close()
+
+
+def test_sentinel():
+    contest = Contest(100000, {'A': 60000, 'B': 40000}, 1, ['A'], ContestType.MAJORITY)
+    minerva = Minerva(.1, .1, contest)
+    minerva.compute_min_winner_ballots([13, 14, 15])
+    assert minerva.min_winner_ballots == [13, None, 14]
+
+
+def test_exceptions():
+    contest = Contest(100000, {'A': 60000, 'B': 40000}, 1, ['A'], ContestType.MAJORITY)
+    minerva = Minerva(.1, .1, contest)
+    with pytest.raises(ValueError):
+        minerva.compute_min_winner_ballots([])
+    with pytest.raises(ValueError):
+        minerva.compute_min_winner_ballots([0])
+    with pytest.raises(ValueError):
+        minerva.compute_min_winner_ballots([1, 2])
+    with pytest.raises(ValueError):
+        minerva.compute_min_winner_ballots([20, 20])
+    with pytest.raises(ValueError):
+        minerva.compute_min_winner_ballots([20, 19])
+    with pytest.raises(ValueError):
+        minerva.compute_min_winner_ballots([10001])
+
+    minerva.compute_min_winner_ballots([20])
+    with pytest.raises(ValueError):
+        minerva.compute_min_winner_ballots([20])
+    with pytest.raises(ValueError):
+        minerva.compute_min_winner_ballots([19])
+    with pytest.raises(ValueError):
+        minerva.compute_min_winner_ballots([10001])

--- a/src/r2b2/tests/test_minerva.py
+++ b/src/r2b2/tests/test_minerva.py
@@ -45,9 +45,19 @@ def test_minerva_kmins():
 
 def test_interactive_minerva():
     runner = CliRunner()
-    user_in = 'minerva\n0.1\n0.1\n100000\n2\nA\n60000\nB\n40000\n1\nA\nMAJORITY\ny\ny\n100\n57\nn\n200\n112\nn\n400\n221\n'
+    user_in = 'minerva\n0.1\n0.1\n100000\n2\nA\n60000\nB\n40000\n1\nA\nMAJORITY\ny\ny\n100\nn\n57\nn\n200\nn\n112\nn\n400\nn\n221\n'
     result = runner.invoke(cli, 'interactive', input=user_in)
     output_file = open('src/r2b2/tests/data/cli_test_expected_out_interactive_minerva.txt', 'r')
+    expected_out = output_file.read()
+    assert result.output == expected_out
+    output_file.close()
+
+
+def test_compute_risk_minerva():
+    runner = CliRunner()
+    user_in = 'minerva\n0.1\n0.1\n100000\n2\nA\n60000\nB\n40000\n1\nA\nMAJORITY\ny\ny\n100\ny\n57\nn\n60\n'
+    result = runner.invoke(cli, 'interactive', input=user_in)
+    output_file = open('src/r2b2/tests/data/cli_test_expected_out_compute_risk_minerva.txt', 'r')
     expected_out = output_file.read()
     assert result.output == expected_out
     output_file.close()

--- a/src/r2b2/tests/test_minerva.py
+++ b/src/r2b2/tests/test_minerva.py
@@ -7,9 +7,9 @@ from r2b2.cli import cli
 from r2b2.contest import Contest
 from r2b2.contest import ContestType
 from r2b2.minerva import Minerva
-import r2b2.tests.util as util
+from r2b2.tests import util as util
 
-default_contest = util.generate_contest(100000)
+default_contest = util.generate_contest(10000)
 
 
 def test_simple_minerva():

--- a/src/r2b2/tests/test_sprob.py
+++ b/src/r2b2/tests/test_sprob.py
@@ -1,0 +1,63 @@
+import pytest
+
+from r2b2.contest import Contest
+from r2b2.contest import ContestType
+from r2b2.minerva import Minerva
+from r2b2.sprob import Sprob
+
+
+def test_simple_sprob():
+    contest = Contest(100000, {'A': 80000, 'B': 20000}, 1, ['A'], ContestType.MAJORITY)
+    round_sched = [10, 100, 200, 1000]
+    kmin_sched = [10, 80, 155, 600]
+    reported_sprob_obj = Sprob(round_sched, kmin_sched, contest)
+    calc_sprobs = reported_sprob_obj.compute_sprobs()
+
+    # From existing software
+    goal_sprobs = [0.10737418240000005, 0.4789618496982295, 0.2758846676307867, 0.13777930027088128]
+    for i in range(len(goal_sprobs)):
+        assert abs(goal_sprobs[i] - calc_sprobs[i]) < .0000001
+    assert abs(reported_sprob_obj.expectation() - 241.92616) < .0001
+
+
+def test_sprob_minerva_agreement():
+    contest_reported = Contest(100000, {'A': 60000, 'B': 40000}, 1, ['A'], ContestType.MAJORITY)
+    contest_tied = Contest(100000, {'A': 50000, 'B': 50000}, 1, ['A'], ContestType.MAJORITY)
+    minerva = Minerva(.1, .1, contest_reported)
+    round_sched = [100, 200, 400]
+    minerva.compute_min_winner_ballots(round_sched)
+    kmin_sched = minerva.min_winner_ballots
+    risk_sched = minerva.risk_schedule
+    sprob_sched = minerva.stopping_prob_schedule
+    reported_sprob_obj = Sprob(round_sched, kmin_sched, contest_reported)
+    tied_sprob_obj = Sprob(round_sched, kmin_sched, contest_tied)
+    calc_risk_sched = tied_sprob_obj.compute_sprobs()
+    calc_sprob_sched = reported_sprob_obj.compute_sprobs()
+    for i in range(len(sprob_sched)):
+        assert abs(risk_sched[i] - calc_risk_sched[i]) < .0000001
+        assert abs(sprob_sched[i] - calc_sprob_sched[i]) < .0000001
+
+
+def test_exceptions():
+    contest = Contest(100000, {'A': 80000, 'B': 20000}, 1, ['A'], ContestType.MAJORITY)
+    with pytest.raises(Exception):
+        sprob = Sprob([], [], contest)
+        sprob.compute_sprobs()
+    with pytest.raises(Exception):
+        sprob = Sprob([10, 11], [10], contest)
+        sprob.compute_sprobs()
+    with pytest.raises(ValueError):
+        sprob = Sprob([0], [0], contest)
+        sprob.compute_sprobs()
+    with pytest.raises(ValueError):
+        sprob = Sprob([1], [0], contest)
+        sprob.compute_sprobs()
+    with pytest.raises(ValueError):
+        sprob = Sprob([10, 10], [8, 9], contest)
+        sprob.compute_sprobs()
+    with pytest.raises(ValueError):
+        sprob = Sprob([1], [2], contest)
+        sprob.compute_sprobs()
+    with pytest.raises(ValueError):
+        sprob = Sprob([10, 11], [10, 12], contest)
+        sprob.compute_sprobs()

--- a/src/r2b2/tests/test_sprob.py
+++ b/src/r2b2/tests/test_sprob.py
@@ -38,6 +38,19 @@ def test_sprob_minerva_agreement():
         assert abs(sprob_sched[i] - calc_sprob_sched[i]) < .0000001
 
 
+def test_sprob_sentinel():
+    contest = Contest(100000, {'A': 95000, 'B': 5000}, 1, ['A'], ContestType.MAJORITY)
+    round_sched = [20, 21, 22]
+    kmin_sched = [20, 21, 21]
+    kmin_sched_sentinel = [20, None, 21]
+    sprob_obj = Sprob(round_sched, kmin_sched, contest)
+    sprob_sentinel_obj = Sprob(round_sched, kmin_sched_sentinel, contest)
+    calc_sprobs = sprob_obj.compute_sprobs()
+    calc_sentinel_sprobs = sprob_sentinel_obj.compute_sprobs()
+    for i in range(len(calc_sprobs)):
+        assert abs(calc_sprobs[i] - calc_sentinel_sprobs[i]) < .0000001
+
+
 def test_exceptions():
     contest = Contest(100000, {'A': 80000, 'B': 20000}, 1, ['A'], ContestType.MAJORITY)
     with pytest.raises(Exception):


### PR DESCRIPTION
Branch to incorporate the sub-contests per discussion with Grant on 7/17.

- [X] Added pairwise sub-contests to contest
- [X] Added pair selection to `audit` instantiation
- [X] Updated dist functions to use pairwise total and winner prop instead of complete contest
- [X] Added pair selection to `cli`
- [X] Added `execute_round()` to audit to execute one round of an audit non-interactively
  - [X] Basic test for method in `test_audit.py`
  - [X] Test for method on minerva
  - [X] Test for method on athena
- [ ] Update `sprop` to reflect new notion of `winner_prop`

**This is not ready to be merged, the update to sprob needs to be figured out.**